### PR TITLE
fix: The class "fullScreen: is used in PDE 

### DIFF
--- a/src/cyclomedia/Widget.vue
+++ b/src/cyclomedia/Widget.vue
@@ -77,7 +77,7 @@ export default {
     widgetClass() {
       let value;
       if (this.$props.orientation === 'full-screen') {
-        value = "medium-24 small-24 height100 fullScreen";
+        value = "medium-24 small-24 height100 fullScreen-cyclo";
       } else if (this.$props.orientation === 'vertical') {
         value = "medium-12 small-24 height100";
       } else {
@@ -342,7 +342,7 @@ export default {
 }
 
 @media screen and (max-width: 749px) {
-  .fullScreen {
+  .fullScreen-cyclo {
     /* display: block; */
     height: 100% !important;
   }


### PR DESCRIPTION
the map was not rendering correctly within the PDE app (map area showed as blank)